### PR TITLE
fix: update installation of kubectl in Dockerfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .tmp
+.cursor
+.history

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,15 @@ FROM alpine:3.17.1
 LABEL org.opencontainers.image.source=https://github.com/doutorfinancas/eks-kubectl
 
 ARG KUBERNETES_VERSION
+RUN test -n "${KUBERNETES_VERSION}" # * Ensures KUBERNETES_VERSION is supplied
 ARG AWS_CLI_VER=2.8.4
+ARG TARGETARCH
 
 RUN apk add jq curl gcompat zip bash aws-cli
 
+RUN echo "curl -s -LO https://dl.k8s.io/release/v${KUBERNETES_VERSION}/bin/linux/${TARGETARCH}/kubectl"
 # Install kubectl
-RUN curl -s -LO https://storage.googleapis.com/kubernetes-release/release/${KUBERNETES_VERSION}/bin/linux/amd64/kubectl && \
+RUN curl -s -LO https://dl.k8s.io/release/v${KUBERNETES_VERSION}/bin/linux/${TARGETARCH}/kubectl && \
     chmod +x ./kubectl && \
     mv ./kubectl /usr/local/bin/kubectl
 

--- a/build-tools/tag.sh
+++ b/build-tools/tag.sh
@@ -1,14 +1,43 @@
 #!/usr/bin/env bash
-set -e
 
-# Input validation
-read -rp "Enter Kubernetes version number: " BUILD_TAG
+set -euo pipefail
 
-echo "$BUILD_TAG"
+readonly IMAGE_REPO='ghcr.io/doutorfinancas/eks-kubectl'
+readonly PLATFORMS='linux/amd64,linux/arm64'
+readonly BASE_KUBECTL_URL='https://dl.k8s.io/release'
 
-docker buildx build \
---push \
---build-arg KUBERNETES_VERSION="$BUILD_TAG" \
---platform linux/arm64,linux/amd64 \
---tag "ghcr.io/doutorfinancas/eks-kubectl:$BUILD_TAG" --tag "ghcr.io/doutorfinancas/eks-kubectl:latest" \
--f "Dockerfile" "."
+# Prompt user for desired minor version
+read -rp 'Enter Kubernetes minor version (e.g., 1.30): ' k8s_version
+readonly k8s_version
+
+if [[ -z "${k8s_version}" ]]; then
+    echo 'error: Kubernetes version cannot be empty' >&2
+    exit 1
+fi
+
+if [[ ${k8s_version} =~ ^[0-9]+\.[0-9]+$ ]]; then
+    echo "[tag.sh] Fetching latest patch for minor release ${k8s_version}..."
+    build_tag=$(curl -fLs --retry 3 "${BASE_KUBECTL_URL}/stable-${k8s_version}.txt")
+    build_tag="${build_tag#v}" # * Strip leading "v"
+
+    if [[ -z "${build_tag}" ]]; then
+        echo 'Error: Unable to determine Kubernetes stable version' >&2
+        exit 1
+    fi
+
+    readonly build_tag
+
+    echo "[tag.sh] Building and tagging with Kubernetes version: ${build_tag}"
+else
+    echo 'Error: Only minor versions (e.g., 1.30) are allowed. Do not include patch' >&2
+     exit 1
+fi
+
+docker buildx build --push --no-cache \
+    --build-arg KUBERNETES_VERSION="${build_tag}" \
+    --platform "${PLATFORMS}" \
+    --tag "${IMAGE_REPO}:${build_tag}" \
+    --tag "${IMAGE_REPO}:latest" \
+    -f Dockerfile .
+
+echo "[tag.sh] Done. Image available as both ${IMAGE_REPO}:${build_tag} and ${IMAGE_REPO}:latest"


### PR DESCRIPTION
- Fix Dockerfile to use TARGETARCH instead of hardcoded amd64
- Fix build-tools/tag.sh to build for linux/amd64,linux/arm64 platforms
- Fix debug.sh to accept architecture parameter and build accordingly
- Add build arg validation to ensure KUBERNETES_VERSION is provided
- Update kubectl installation URL to use dl.k8s.io (the current one seems outdated)
- Enhance README.md with build instructions and security best practices
- Add IDE-specific entries to .gitignore

The previous scripts were incorrectly building only amd64 images despite multi-arch being intended functionality.